### PR TITLE
try fix #27

### DIFF
--- a/src/common/platform/PlatformHelper.js
+++ b/src/common/platform/PlatformHelper.js
@@ -48,6 +48,9 @@ export default class PlatformHelper {
         return currentPlatform.isMobile;
     }
 
+    /**
+     * @return {string}
+     */
     static get PlatformType() {
         return currentPlatform.PlatformType;
     }

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -108,7 +108,7 @@
           </el-tooltip>
         </div>
         <el-divider content-position="left">调整蹲饼器</el-divider>
-        <el-row type="flex" justify="center">
+        <el-row class="menu-button-area" type="flex" justify="center">
           <el-button type="primary" @click="openGithub" icon="el-icon-star-off"
           >点个star
           </el-button
@@ -369,10 +369,14 @@ export default {
     },
     listenerWindowSize() {
       if (!PlatformHelper.isMobile) {
+        // 只在从大窗口缩小的时候提示(第一次除外)
+        let fromLarge = true;
         window.onresize = () => {
-          if (window.innerWidth <= 699) {
+          // 425和348两个魔法值来源于：https://discourse.mozilla.org/t/can-add-ons-webextensions-popups-determinate-whether-they-are-shown-in-the-overflow-menu-or-not/27937/6
+          if (fromLarge && window.innerWidth <= 699 && window.innerWidth !== 425 && window.innerWidth !== 348) {
             alert("窗口太小,可能显示出现问题");
           }
+          fromLarge = window.innerWidth > 699;
         };
       }
     },
@@ -738,6 +742,52 @@ export default {
 </style>
 
 <style lang="less">
+@media (max-width: 699px) {
+  .online-area {
+    align-items: flex-start !important;
+    font-size: xx-small;
+  }
+  .online-title-img,.sane-area,.day-info-content-bottom {
+    display: none !important;
+  }
+  .el-loading-spinner {
+    top: 0 !important;
+    margin-top: 0 !important;
+  }
+  .el-timeline {
+    padding-left: 20px !important;
+    padding-right: 10px !important;
+  }
+  .el-timeline-item__timestamp {
+    margin-left: 13px !important;
+  }
+  .el-timeline-item__wrapper {
+    padding-left: 14px !important;
+  }
+  .el-divider--horizontal {
+    display: flex !important;
+    justify-content: center !important;
+    .el-divider__text.is-left {
+      left: unset !important;
+    }
+  }
+  .el-drawer {
+    width: 100% !important;
+  }
+  .drawer-btn-area {
+    flex-wrap: wrap;
+    .el-button {
+      margin: 3px !important;
+    }
+  }
+  .menu-button-area {
+    flex-wrap: wrap;
+    .el-button {
+      width: 40% !important;
+      margin: 3px !important;
+    }
+  }
+}
 body {
   margin: 0;
 }

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -368,11 +368,13 @@ export default {
       // this.janvas.start();
     },
     listenerWindowSize() {
-      window.onresize = (data) => {
-        if (window.innerWidth <= 699) {
-          alert("窗口太小,可能显示出现问题");
-        }
-      };
+      if (!PlatformHelper.isMobile) {
+        window.onresize = () => {
+          if (window.innerWidth <= 699) {
+            alert("窗口太小,可能显示出现问题");
+          }
+        };
+      }
     },
     scrollHandler() {
       let scrollDiv = this.$refs.drawerBtnAreaQuickJump;


### PR DESCRIPTION
样式测试：可在chrome中开窗口模式然后缩小窗口测试
实现原理：css media

未测试：在firefox上按照 #27 中的方式打开popup时应当不弹框提示，由于不知道firefox怎么调试故无法测试
不弹框的原理为：检测宽度为348/425px时不弹框，348和425根据[参考链接](https://discourse.mozilla.org/t/can-add-ons-webextensions-popups-determinate-whether-they-are-shown-in-the-overflow-menu-or-not/27937/6)应该是firefox的预设宽度